### PR TITLE
Stop listening pr open reopen sync events

### DIFF
--- a/src/http/post-api-github-webhooks/app.js
+++ b/src/http/post-api-github-webhooks/app.js
@@ -4,14 +4,7 @@
 module.exports = (app) => {
   app.log("Yay! The app was loaded!");
 
-  app.on(
-    [
-      "pull_request.opened",
-      "pull_request.reopened",
-      "pull_request.synchronize",
-      "pull_request.edited",
-    ],
-    async (context) => {
+  app.on("pull_request.edited", async (context) => {
       context.log.debug("PR Opened or PR Synchronized!");
       const {
         payload: { pull_request, repository },

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -27,6 +27,8 @@ testPRSingleCommit.before.each(() => {
   probot.load(app);
 });
 
+testPRSingleCommit.after(nock.cleanAll)
+
 const owner = "my-username";
 const repo = "my-awesome-repo";
 const prNumber = 1;
@@ -35,21 +37,21 @@ const branchName = "branch-name-pr";
 const treeSha = "691272480426f78a0138979dd3ce63b77f706feb";
 const emptyCommitSha = "7638417db6d59f3c431d3e1f261cc637155684cd";
 const ref = `heads%2F${branchName}`;
+const prEventsListened = ["edited"]
+const prEventsIgnored = ["opened", "reopened", "synchronize", "edited"]
 
-["opened", "reopened", "synchronize", "edited"].forEach((prEvent) => {
+prEventsListened.forEach((prEvent) => {
   testPRSingleCommit(
     `recieves pull_request.${prEvent} event`,
     async function () {
       const mock = nock("https://api.github.com")
         .get(`/repos/${owner}/${repo}/pulls/${prNumber}`)
         .reply(200, {
-          // data: {
           commits: 1,
           head: {
             sha: commitSha,
             ref: branchName,
           },
-          // },
         })
         .get(`/repos/${owner}/${repo}/git/commits/${commitSha}`)
         .reply(200, {
@@ -85,7 +87,7 @@ Learn more at https://github.com/squash-commit-app/squash-commit-app`,
         name: "pull_request",
         id: "1",
         payload: {
-          action: "opened",
+          action: prEvent,
           repository: {
             owner: {
               login: owner,
@@ -103,26 +105,96 @@ Learn more at https://github.com/squash-commit-app/squash-commit-app`,
   );
 });
 
+prEventsIgnored.forEach((prEvent) => {
+  testPRSingleCommit(
+    `ignores pull_request.${prEvent} event`,
+    async function () {
+      const mock = nock("https://api.github.com")
+        .get(`/repos/${owner}/${repo}/pulls/${prNumber}`)
+        .reply(200, {
+          commits: 1,
+          head: {
+            sha: commitSha,
+            ref: branchName,
+          },
+        })
+        .get(`/repos/${owner}/${repo}/git/commits/${commitSha}`)
+        .reply(200, {
+          sha: commitSha,
+          tree: {
+            sha: treeSha,
+          },
+        })
+        .post(`/repos/${owner}/${repo}/git/commits`, (requestBody) => {
+          equal(requestBody, {
+            message: `empty commit to preset the squash & merge commit subject from the pull request title
+
+Learn more at https://github.com/squash-commit-app/squash-commit-app`,
+            tree: treeSha,
+            parents: [commitSha],
+          });
+
+          return true;
+        })
+        .reply(201, {
+          sha: emptyCommitSha,
+        })
+        .patch(`/repos/${owner}/${repo}/git/refs/${ref}`, (requestBody) => {
+          equal(requestBody, {
+            sha: emptyCommitSha,
+          });
+
+          return true;
+        })
+        .reply(200);
+
+      await probot.receive({
+        name: "pull_request",
+        id: "1",
+        payload: {
+          action: prEvent,
+          repository: {
+            owner: {
+              login: owner,
+            },
+            name: repo,
+          },
+          pull_request: {
+            number: prNumber,
+          },
+        },
+      });
+
+      equal(mock.pendingMocks().length, 4)
+      equal(mock.pendingMocks(), [
+       `GET https://api.github.com:443/repos/${owner}/${repo}/pulls/${prNumber}`,
+       `GET https://api.github.com:443/repos/${owner}/${repo}/git/commits/${commitSha}`,
+       `POST https://api.github.com:443/repos/${owner}/${repo}/git/commits`,
+       `PATCH https://api.github.com:443/repos/${owner}/${repo}/git/refs/${ref}`
+      ]);
+
+    }
+  );
+});
+
 testPRSingleCommit.run();
 
 // ---
 
 const testPRWithMultipleCommits = suite("with Multiple Commits");
 
-["opened", "reopened", "synchronize", "edited"].forEach((prEvent) => {
+prEventsListened.forEach((prEvent) => {
   testPRWithMultipleCommits(
     `recieves pull_request.${prEvent} event`,
     async function () {
       const mock = nock("https://api.github.com")
         .get(`/repos/${owner}/${repo}/pulls/${prNumber}`)
         .reply(200, {
-          // data: {
           commits: 11,
           head: {
             sha: commitSha,
             ref: branchName,
           },
-          // },
         });
 
       await probot.receive({


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
GitHub App stops listening to the following PR events:
* `pull_requrest.opened`
* `pull_request.reopened`
* `pull_request.synchronized`

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
GitHub App `squash-commit-app` from now on will only listen to `pull_request.edited` events. This way, contributors will have control on when the bot is triggered (usually when editing the tittle).

This will solve some frictions the app has been causing when it was run on `pull_request.opened` events:
* Fixes #13 
* Fixes #6 
* Fixes #7

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pending to run the app locally, since the change is pretty straight forward, are we ready to land it and try it in a controlled repo like https://github.com/gr2m/sandbox?
