### PR TITLE
fix(release): use node-version 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
           cache: npm
       - run: npx semantic-release
         env:


### PR DESCRIPTION
latest semantic-release requires node 14.17 or >=16 to run